### PR TITLE
Explicitly set Content-Length for tests

### DIFF
--- a/src/test/scala/todomvc/api.scala
+++ b/src/test/scala/todomvc/api.scala
@@ -125,8 +125,13 @@ trait ApiMocks extends Scope {
 trait HttpHelpers {
   def jsonRequest[A: Encoder](method: Method, uri: String)(content: A) = {
     val req = Request(method = method, uri = uri)
-    req.setContentString(content.asJson.noSpaces)
+
+    val jsonContent = content.asJson.noSpaces
+
     req.setContentType("application/json")
+    req.setContentString(jsonContent)
+    req.contentLength = jsonContent.length
+
     req
   }
 


### PR DESCRIPTION
This isn’t set and required for Finagle (?) to read the content.
