### PR TITLE
Work around for e.target is null

### DIFF
--- a/js/src/main/scala/todomvc/client/TodoView.scala
+++ b/js/src/main/scala/todomvc/client/TodoView.scala
@@ -39,7 +39,10 @@ object TodoView {
       }
 
     val editFieldChanged: ReactEventI => Callback =
-      e => $.modState(_.copy(editText = e.target.value))
+      e => {
+        val text = e.target.value
+        $.modState(_.copy(editText = text))
+      }
 
     def render(p: Props, s: State): ReactElement = {
       <.li(


### PR DESCRIPTION
Editing a todo produces `e$1.target is null` in the console, and the edit is lost.

This PR applies the change from https://github.com/japgolly/scalajs-react/issues/255

Double checking this, I see the same change in the todomvc Scala demo: https://github.com/tastejs/todomvc/blob/gh-pages/examples/scalajs-react/src/main/scala/todomvc/TodoItem.scala#L50-L55